### PR TITLE
discordbot.pyのpurgeコマンドにcheckを追加し、ピン止めを消さないようにして、nの指定ミスによる誤爆対策を仮実装しました。

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -404,7 +404,9 @@ async def purge(ctx: discord.Interaction, n: int):
     if ctx.permissions.manage_messages is not True:
         await ctx.followup.send(">>> **このコマンドはヘルパー以上の役職を持っていないと使うことはできません.**")
         return
-    deleted = await ctx.channel.purge(limit=n)
+    def not_info(m):
+        return not m.pinned
+    deleted = await ctx.channel.purge(limit=n, check=not_info)
     await ctx.followup.send((">>> メッセージを{}件削除しました.".format(len(deleted))))
     # await ctx.delete_original_response()
 


### PR DESCRIPTION
discordbot.pyの407行目、`deleted = await ctx.channel.purge(limit=n)`を
```
def not_info(m):
    return not m.pinned
deleted = await ctx.channel.purge(limit=n, check=not_info)
```
に変更しています。
ローカルでの検証は出来ていません。